### PR TITLE
UDCSL #114 - Replace media

### DIFF
--- a/app/models/concerns/triple_eye_effable/resourceable.rb
+++ b/app/models/concerns/triple_eye_effable/resourceable.rb
@@ -29,21 +29,29 @@ module TripleEyeEffable
       def create_resource
         service = TripleEyeEffable::Cloud.new
         service.create_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def delete_resource
         service = TripleEyeEffable::Cloud.new
         service.delete_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def load_resource
         service = TripleEyeEffable::Cloud.new
         service.load_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def update_resource
         service = TripleEyeEffable::Cloud.new
         service.update_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
     end
   end


### PR DESCRIPTION
This pull request fixes a bug where the `triple-eye-effable` gem was not correctly handling errors on responses from IIIF Cloud. This change will update the callbacks in the `resourceable` model to abort the create/update/destroy/find if an error is received from IIIF Cloud.

This pull request also updates the gem to only send the `content` attribute if present on the model. This is very important because the content should only be sent to the API when it is being changed. Sending empty content to IIIF Cloud will remove existing images erroneously. 