### PR TITLE
UDCSL #114 - Replace media

### DIFF
--- a/app/models/concerns/triple_eye_effable/resourceable.rb
+++ b/app/models/concerns/triple_eye_effable/resourceable.rb
@@ -29,21 +29,29 @@ module TripleEyeEffable
       def create_resource
         service = TripleEyeEffable::Cloud.new
         service.create_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def delete_resource
         service = TripleEyeEffable::Cloud.new
         service.delete_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def load_resource
         service = TripleEyeEffable::Cloud.new
         service.load_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
 
       def update_resource
         service = TripleEyeEffable::Cloud.new
         service.update_resource(self)
+
+        throw(:abort) unless self.errors.empty?
       end
     end
   end

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -63,7 +63,7 @@ module TripleEyeEffable
     private
 
     def add_error(resourceable, response)
-      message = response['exception'] || response['message']
+      message = response['exception'] || response['message'] || response['errors']
       resourceable.errors.add(:base, message)
     end
 

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -92,7 +92,6 @@ module TripleEyeEffable
     def request_body(resourceable)
       name = resourceable.name.force_encoding(Encoding::ASCII_8BIT) if resourceable.respond_to?(:name)
       content = resourceable.content if resourceable.respond_to?(:content)
-      content_remove = resourceable.content_remove if resourceable.respond_to?(:content_remove)
       metadata = resourceable.metadata if resourceable.respond_to?(:metadata)
 
       body =       {

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -47,7 +47,7 @@ module TripleEyeEffable
       return if resourceable.resource_description.nil?
 
       resource_description = resourceable.resource_description
-      response = self.class.get("#{base_url}/#{resource_description.resource_id}")
+      response = self.class.get("#{base_url}/#{resource_description.resource_id}", headers: headers)
       add_error(resourceable, response) and return unless response.success?
 
       resource_id, data = parse_response(response)


### PR DESCRIPTION
Re-opening reverted PR to allow other hotfixes first. Due to the error-throwing bugfix in this PR, errors in `resource-api`, IIIF Cloud, and consuming applications need to be resolved before merging.

> This pull request fixes a bug where the `triple-eye-effable` gem was not correctly handling errors on responses from IIIF Cloud. This change will update the callbacks in the `resourceable` model to abort the create/update/destroy/find if an error is received from IIIF Cloud.
>
> This pull request also updates the gem to only send the `content` attribute if present on the model. This is very important because the content should only be sent to the API when it is being changed. Sending empty content to IIIF Cloud will remove existing images erroneously. 