### PR TITLE
UDCSL #116 - Videos/PDFs

### DIFF
--- a/app/models/concerns/triple_eye_effable/resourceable.rb
+++ b/app/models/concerns/triple_eye_effable/resourceable.rb
@@ -13,6 +13,7 @@ module TripleEyeEffable
       delegate :content_url, to: :resource_description, allow_nil: true
       delegate :content_download_url, to: :resource_description, allow_nil: true
       delegate :content_iiif_url, to: :resource_description, allow_nil: true
+      delegate :content_inline_url, to: :resource_description, allow_nil: true
       delegate :content_preview_url, to: :resource_description, allow_nil: true
       delegate :content_thumbnail_url, to: :resource_description, allow_nil: true
       delegate :content_type, to: :resource_description, allow_nil: true

--- a/app/models/triple_eye_effable/resource_description.rb
+++ b/app/models/triple_eye_effable/resource_description.rb
@@ -4,6 +4,7 @@ module TripleEyeEffable
     attr_accessor :content_url
     attr_accessor :content_download_url
     attr_accessor :content_iiif_url
+    attr_accessor :content_inline_url
     attr_accessor :content_preview_url
     attr_accessor :content_thumbnail_url
     attr_accessor :content_type

--- a/app/serializers/triple_eye_effable/resourceable_serializer.rb
+++ b/app/serializers/triple_eye_effable/resourceable_serializer.rb
@@ -3,8 +3,10 @@ module TripleEyeEffable
     extend ActiveSupport::Concern
 
     included do
-      index_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_preview_url, :content_thumbnail_url, :manifest
-      show_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_preview_url, :content_thumbnail_url, :manifest
+      index_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_inline_url,
+                       :content_preview_url, :content_thumbnail_url, :manifest
+      show_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_inline_url,
+                      :content_preview_url, :content_thumbnail_url, :manifest
     end
 
   end

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -10,6 +10,7 @@ module TripleEyeEffable
       content_url
       content_download_url
       content_iiif_url
+      content_inline_url
       content_preview_url
       content_thumbnail_url
       content_type


### PR DESCRIPTION
This pull request adds the `content_inline_url` attribute to the list of attributes included from resources pulled from IIIF Cloud. This is necessary in order to generate a URL that can be used to open a PDF in a new tab/window.