### PR TITLE
Add content_info_url (#16)

### DIFF
--- a/app/models/concerns/triple_eye_effable/resourceable.rb
+++ b/app/models/concerns/triple_eye_effable/resourceable.rb
@@ -13,6 +13,7 @@ module TripleEyeEffable
       delegate :content_url, to: :resource_description, allow_nil: true
       delegate :content_download_url, to: :resource_description, allow_nil: true
       delegate :content_iiif_url, to: :resource_description, allow_nil: true
+      delegate :content_info_url, to: :resource_description, allow_nil: true
       delegate :content_inline_url, to: :resource_description, allow_nil: true
       delegate :content_preview_url, to: :resource_description, allow_nil: true
       delegate :content_thumbnail_url, to: :resource_description, allow_nil: true

--- a/app/models/triple_eye_effable/resource_description.rb
+++ b/app/models/triple_eye_effable/resource_description.rb
@@ -7,6 +7,7 @@ module TripleEyeEffable
     attr_accessor :content_url
     attr_accessor :content_download_url
     attr_accessor :content_iiif_url
+    attr_accessor :content_info_url
     attr_accessor :content_inline_url
     attr_accessor :content_preview_url
     attr_accessor :content_thumbnail_url

--- a/app/serializers/triple_eye_effable/resourceable_serializer.rb
+++ b/app/serializers/triple_eye_effable/resourceable_serializer.rb
@@ -4,9 +4,9 @@ module TripleEyeEffable
 
     included do
       index_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_inline_url,
-                       :content_preview_url, :content_thumbnail_url, :manifest_url
+                       :content_info_url, :content_preview_url, :content_thumbnail_url, :manifest_url
       show_attributes :content_type, :content_url, :content_download_url, :content_iiif_url, :content_inline_url,
-                      :content_preview_url, :content_thumbnail_url, :manifest_url
+                      :content_info_url, :content_preview_url, :content_thumbnail_url, :manifest_url
     end
 
   end

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -10,6 +10,7 @@ module TripleEyeEffable
       content_url
       content_download_url
       content_iiif_url
+      content_info_url
       content_inline_url
       content_preview_url
       content_thumbnail_url
@@ -72,6 +73,7 @@ module TripleEyeEffable
         content_url: "#{base_url}/#{id}/content",
         content_download_url: "#{base_url}/#{id}/download",
         content_iiif_url: "#{base_url}/#{id}/iiif",
+        content_info_url: "#{base_url}/#{id}/info",
         content_inline_url: "#{base_url}/#{id}/inline",
         content_preview_url: "#{base_url}/#{id}/preview",
         content_thumbnail_url: "#{base_url}/#{id}/thumbnail",


### PR DESCRIPTION
## In this PR

Add the attribute `content_info_url`, which should be the same as the equivalent url on IIIF Cloud.

## Questions

Is this sufficient, or do we need to populate this attribute for existing records? (Having trouble telling if this URL is computed on the fly or stored)