### PR TITLE
CDC #475 - Import media

### DIFF
--- a/app/models/concerns/triple_eye_effable/resourceable.rb
+++ b/app/models/concerns/triple_eye_effable/resourceable.rb
@@ -20,18 +20,11 @@ module TripleEyeEffable
       delegate :manifest_url, to: :resource_description, allow_nil: true
 
       # Callbacks
-      before_create :create_resource
+      before_create :save_resource
       before_destroy :delete_resource
-      before_update :update_resource
+      before_update :save_resource
 
       private
-
-      def create_resource
-        service = TripleEyeEffable::Cloud.new
-        service.create_resource(self)
-
-        throw(:abort) unless self.errors.empty?
-      end
 
       def delete_resource
         service = TripleEyeEffable::Cloud.new
@@ -40,9 +33,9 @@ module TripleEyeEffable
         throw(:abort) unless self.errors.empty?
       end
 
-      def update_resource
+      def save_resource
         service = TripleEyeEffable::Cloud.new
-        service.update_resource(self)
+        service.save_resource(self)
 
         throw(:abort) unless self.errors.empty?
       end

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -79,6 +79,14 @@ module TripleEyeEffable
       )
     end
 
+    def save_resource(resourceable)
+      if resourceable.resource_description.present?
+        update_resource resourceable
+      else
+        create_resource resourceable
+      end
+    end
+
     def update_resource(resourceable)
       raise I18n.t('errors.read_only') if @read_only
 


### PR DESCRIPTION
This pull request updates the `resourceable` concern to "lazy save", records rather than explicit create/update. If the related `resource_description` exists, the record will be updated. If not, it will be created. 

This is needed to support import media records in `core-data-cloud`. The import process creates the underlying `media_contents` record via SQL, then goes through and uploads all of the attachments. 