### PR TITLE
Archnet #1549 - Direct uploads

### DIFF
--- a/app/controllers/triple_eye_effable/application_controller.rb
+++ b/app/controllers/triple_eye_effable/application_controller.rb
@@ -1,4 +1,4 @@
 module TripleEyeEffable
-  class ApplicationController < ActionController::API
+  class ApplicationController < TripleEyeEffable.config.base_controller_class.constantize
   end
 end

--- a/app/controllers/triple_eye_effable/application_controller.rb
+++ b/app/controllers/triple_eye_effable/application_controller.rb
@@ -1,4 +1,4 @@
 module TripleEyeEffable
-  class ApplicationController < ActionController::Base
+  class ApplicationController < ActionController::API
   end
 end

--- a/app/controllers/triple_eye_effable/direct_uploads_controller.rb
+++ b/app/controllers/triple_eye_effable/direct_uploads_controller.rb
@@ -1,0 +1,21 @@
+module TripleEyeEffable
+  class DirectUploadsController < ApplicationController
+    # Actions
+    before_action do |controller|
+      next unless TripleEyeEffable.config.authenticate.present?
+      controller.send(TripleEyeEffable.config.authenticate)
+    end
+
+    def create
+      response = DirectUploads.new.direct_upload(direct_upload_params)
+      render json: response, status: response.code
+    end
+
+    private
+
+    def direct_upload_params
+      params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {})
+    end
+
+  end
+end

--- a/app/controllers/triple_eye_effable/direct_uploads_controller.rb
+++ b/app/controllers/triple_eye_effable/direct_uploads_controller.rb
@@ -1,10 +1,7 @@
 module TripleEyeEffable
   class DirectUploadsController < ApplicationController
     # Actions
-    before_action do |controller|
-      next unless TripleEyeEffable.config.authenticate.present?
-      controller.send(TripleEyeEffable.config.authenticate)
-    end
+    before_action :set_metadata, only: :create
 
     def create
       response = DirectUploads.new.direct_upload(direct_upload_params)
@@ -15,6 +12,11 @@ module TripleEyeEffable
 
     def direct_upload_params
       params.require(:blob).permit(:filename, :byte_size, :checksum, :content_type, metadata: {})
+    end
+
+    def set_metadata
+      params[:blob][:metadata] ||= {}
+      params[:blob][:metadata][:storage_key] = request.headers['X-STORAGE-KEY']
     end
 
   end

--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -150,8 +150,12 @@ module TripleEyeEffable
 
       # Only send content if it's being changed
       if content.present?
-        # handle unicode in original_filename
-        content.original_filename = content.original_filename.force_encoding(Encoding::ASCII_8BIT)
+        # Handle unicode in original_filename
+        if content.respond_to?(:original_filename)
+          content.original_filename = content.original_filename.force_encoding(Encoding::ASCII_8BIT)
+        end
+
+        # Append the content to the body
         body[:resource][:content] = content
       end
 

--- a/app/services/triple_eye_effable/direct_uploads.rb
+++ b/app/services/triple_eye_effable/direct_uploads.rb
@@ -19,7 +19,7 @@ module TripleEyeEffable
     private
 
     def headers
-      { 'X-API-KEY' => api_key }
+      { 'X-API-KEY': api_key }
     end
 
   end

--- a/app/services/triple_eye_effable/direct_uploads.rb
+++ b/app/services/triple_eye_effable/direct_uploads.rb
@@ -1,0 +1,26 @@
+require 'httparty'
+
+module TripleEyeEffable
+  class DirectUploads
+    # Includes
+    include HTTParty
+
+    attr_reader :api_key, :api_url
+
+    def initialize(api_key: nil, api_url: nil)
+      @api_key = api_key || TripleEyeEffable.config.api_key
+      @api_url = api_url || TripleEyeEffable.config.url
+    end
+
+    def direct_upload(blob)
+      self.class.post("#{api_url}/rails/active_storage/direct_uploads", body: { blob: }, headers:)
+    end
+
+    private
+
+    def headers
+      { 'X-API-KEY' => api_key }
+    end
+
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,3 @@
 TripleEyeEffable::Engine.routes.draw do
+  post '/direct_uploads', to: 'direct_uploads#create'
 end

--- a/lib/triple_eye_effable/configuration.rb
+++ b/lib/triple_eye_effable/configuration.rb
@@ -2,4 +2,5 @@ class Configuration
   attr_accessor :api_key
   attr_accessor :url
   attr_accessor :project_id
+  attr_accessor :authenticate
 end

--- a/lib/triple_eye_effable/configuration.rb
+++ b/lib/triple_eye_effable/configuration.rb
@@ -2,5 +2,9 @@ class Configuration
   attr_accessor :api_key
   attr_accessor :url
   attr_accessor :project_id
-  attr_accessor :authenticate
+  attr_accessor :base_controller
+
+  def base_controller_class
+    self.base_controller || 'ActionController::API'
+  end
 end


### PR DESCRIPTION
This pull request makes the following changes to support [#1549](https://github.com/performant-software/archnet3/issues/1549) for Archnet:

- Adds the `/direct_upload` API endpoint. This endpoint will call the `active_storage/direct_uploads` API endpoint on the host provided in the config
- Adds the `base_controller` config option to allow authentication and authorization for `/direct_upload` endpoint
- Adds a check for encoding the `original_filename`. With direct uploads the `content` attribute will be a string (signed ID)
