### PR TITLE
IIIF #110 - Object prefixes

### DIFF
--- a/app/controllers/triple_eye_effable/direct_uploads_controller.rb
+++ b/app/controllers/triple_eye_effable/direct_uploads_controller.rb
@@ -15,6 +15,8 @@ module TripleEyeEffable
     end
 
     def set_metadata
+      return unless request.headers['X-STORAGE-KEY'].present?
+
       params[:blob][:metadata] ||= {}
       params[:blob][:metadata][:storage_key] = request.headers['X-STORAGE-KEY']
     end


### PR DESCRIPTION
This pull request updates the `direct_uploads_controller` to only set the `metadata.storage_key` value if the `X-STORAGE-KEY` request header is present. This will result in the `metadata.storage_key` not being set to an empty string value.