### PR TITLE
Only encode filename ASCII in binary file transfer (Archnet #1627)

### DIFF
--- a/app/services/triple_eye_effable/cloud.rb
+++ b/app/services/triple_eye_effable/cloud.rb
@@ -21,7 +21,7 @@ module TripleEyeEffable
     )
 
     def self.filename(name)
-      name&.force_encoding(Encoding::ASCII_8BIT)
+      name&.dup&.force_encoding(Encoding::ASCII_8BIT)
     end
 
     def initialize(api_key: nil, api_url: nil, project_id: nil, read_only: false)
@@ -134,7 +134,7 @@ module TripleEyeEffable
     end
 
     def request_body(resourceable)
-      name = self.class.filename(resourceable.name) if resourceable.respond_to?(:name)
+      name = resourceable.name if resourceable.respond_to?(:name)
       content = resourceable.content if resourceable.respond_to?(:content)
       metadata = resourceable.metadata if resourceable.respond_to?(:metadata)
       storage_key = resourceable.storage_key if resourceable.respond_to?(:storage_key)
@@ -152,7 +152,7 @@ module TripleEyeEffable
       if content.present?
         # Handle unicode in original_filename
         if content.respond_to?(:original_filename)
-          content.original_filename = content.original_filename.force_encoding(Encoding::ASCII_8BIT)
+          content.original_filename = self.class.filename(content.original_filename)
         end
 
         # Append the content to the body


### PR DESCRIPTION
### In this PR

Per performant-software/archnet3#1627:
- Only use `TripleEyeEffable::Cloud.filename`, which forces ASCII-8BIT encoding, in the `content` part of a multipart POST file upload request body
   - Remove it from the resourceable's `name`, since it should be possible to store it in the DB as UTF-8
- Use `.dup` to ensure we're only mutating a copy of the data

### Notes

The original actual error from Archnet was:
```
12:17:06 PM api.1      |  Completed 500 Internal Server Error in 426ms (ActiveRecord: 34.2ms | Allocations: 39166)
12:17:06 PM api.1      |  Encoding::UndefinedConversionError ("\xC3" from ASCII-8BIT to UTF-8):
```
